### PR TITLE
Termination character

### DIFF
--- a/CliTerminal.cpp
+++ b/CliTerminal.cpp
@@ -24,6 +24,7 @@ void Cli_Terminal::cli_cal()
             return;
         }
         String command = Serial.readStringUntil((char)10);
+        command.trim();
         Serial.println(command);
         String processed[2];
         *processed = *TextProcessor(command, processed);


### PR DESCRIPTION
I used your library and had the issue that putty did not support sensing commands with only a /n. I tried adding /r to all my command definitions. This worked until I started using the command parameters. In this case the /r  is appended to the end of the parameter and not to the command and the command can not be recognised by your library.

I think adding a simple trim command could fix this issue. Please have a look at my modification.